### PR TITLE
chore: add Cloudflare MCP server to project config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "cloudflare": {
+      "type": "http",
+      "url": "https://mcp.cloudflare.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.mcp.json` registering the official Cloudflare remote MCP server (`https://mcp.cloudflare.com/mcp`) as a project-scoped MCP.
- New Claude Code sessions opened against this repo will discover the `cloudflare` MCP at startup. Auth is OAuth 2.1 on first use; no secrets are stored in the repo.

## Test plan
- [ ] Start a fresh Claude Code session from this branch and confirm the `cloudflare` MCP appears in the available tools.
- [ ] Complete the OAuth flow on first use.
- [ ] Run a simple Cloudflare MCP call (e.g. list accounts / zones) to confirm the connection works end-to-end.

https://claude.ai/code/session_01QerFgQRbE1B5znnSnMgE9K

---
_Generated by [Claude Code](https://claude.ai/code/session_01QerFgQRbE1B5znnSnMgE9K)_